### PR TITLE
Fixes blog item link in paginated results

### DIFF
--- a/components/ListItem.tsx
+++ b/components/ListItem.tsx
@@ -18,7 +18,7 @@ export function ListItem({ slug, title, date, location, path, tags = [], summary
         <div className="space-y-6">
           <div>
             <h2 className="text-2xl font-bold leading-8 tracking-tight">
-              <Link href={path} className="text-gray-900 dark:text-gray-100">
+              <Link href={`/${path}`} className="text-gray-900 dark:text-gray-100">
                 {title}
               </Link>
             </h2>


### PR DESCRIPTION
When paging through results we were using the path, but not prepending with a slash. This resulted in the linked path being appended, resulting in a 404.