### PR TITLE
pages: add `min-h-screen` to body to stretch background

### DIFF
--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -9,7 +9,7 @@ class MyDocument extends Document {
         <Head>
           <link rel="alternate" type="application/rss+xml" href="/feed.xml" />
         </Head>
-        <body className="text-black bg-white antialiased dark:bg-gray-900 dark:text-white">
+        <body className="text-black min-h-screen bg-white antialiased dark:bg-gray-900 dark:text-white">
           <Main />
           <NextScript />
         </body>


### PR DESCRIPTION
This fixes dark mode not being full screen on smaller pages.

Fixes: #33