### PR TITLE
Set name of Github action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
 jobs:
   test:
+    name: test
     timeout-minutes: 20
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The action name is required to use with branch protection rules. With that, we will also be able to set auto-merge after a review and successful CI run.

Related to https://github.com/tailscale-dev/tailscale-dev/issues/38