### PR TITLE
.github/workflows: [fly.yml] change deploy to `--local-only`

### DIFF
--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -11,5 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: docker/setup-buildx-action@v2
       - uses: superfly/flyctl-actions/setup-flyctl@master
-      - run: flyctl deploy --remote-only
+      - run: flyctl deploy --local-only


### PR DESCRIPTION
Changing to `flyctl deploy --local-only` to try and improve deploy times. We should be able to use GitHub Actions to build the container and just push it to Fly.io. This should be faster since we're not waiting on their builder to be available instead, we're using the existing runner to do the build.

Updates: #36