### PR TITLE
lib/utils: [contentlayer] sort events in ascending order

### DIFF
--- a/lib/utils/contentlayer.ts
+++ b/lib/utils/contentlayer.ts
@@ -14,18 +14,12 @@ export type MDXAuthor = MDXDocument & {
   name: string;
 };
 
-export function dateSortDesc(a: string, b: string) {
-  if (a > b) return -1;
-  if (a < b) return 1;
-  return 0;
-}
-
 export function sortedBlogPost(allBlogs: MDXDocumentDate[]) {
-  return allBlogs.sort((a, b) => dateSortDesc(a.date, b.date));
+  return allBlogs.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
 }
 
 export function sortedEventPosts(allEvents: MDXDocumentDate[]) {
-  return allEvents.sort((a, b) => dateSortDesc(a.date, b.date));
+  return allEvents.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
 }
 
 type ConvertUndefined<T> = OrNull<{


### PR DESCRIPTION
Events should be ascending order with the most recent event first. Blog posts are opposite.

I removed the `dateSortDesc` function because it wasn't really date specific. It was also exported but not used anywhere else.

I inlined the sort and parse the date so we can do `a-b`, `b-a` sorting.

Fixes: #29

Signed-off-by: Shayne Sweeney <shayne@tailscale.com>