### PR TITLE
envrc: Make nix optional, PATH_add tool dir

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,5 @@
-use flake
+if has nix; then
+    use flake
+fi
+
+PATH_add tool


### PR DESCRIPTION
For folks who use direnv this will make sure ./tool scripts are in their path (yarn and node right now).

Signed-off-by: Shayne Sweeney <shayne@tailscale.com>