### PR TITLE
Refactor how we display dates

### DIFF
--- a/components/DateDisplay.tsx
+++ b/components/DateDisplay.tsx
@@ -1,0 +1,21 @@
+import { toLocaleUTCDateString } from '@/lib/utils/date';
+
+export function DateDisplay({ dateString }) {
+  if (dateString.match(/^\d{4}-\d{2}-\d{2}/)) {
+    const d = new Date(dateString);
+
+    const options: Intl.DateTimeFormatOptions = {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    };
+
+    // display the time in UTC to avoid using the browser's
+    // timezone, resulting in a hydration error
+    const formattedDate = toLocaleUTCDateString(d, undefined, options);
+
+    return <time dateTime={dateString}>{formattedDate}</time>;
+  }
+
+  return <time dateTime={dateString}>{dateString}</time>;
+}

--- a/components/ListItem.tsx
+++ b/components/ListItem.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import Tag from '@/components/Tag';
+import { DateDisplay } from '@/components/DateDisplay';
 
 interface ListItemProps {
   slug: string;
@@ -23,9 +24,7 @@ export function ListItem({ slug, title, date, location, path, tags = [], summary
 
             <div className="font-mono text-base font-medium leading-6">
               <span className="pr-4">&frasl;&frasl;</span>
-              <time dateTime={date} suppressHydrationWarning>
-                {date}
-              </time>
+              <DateDisplay dateString={date} />
               {tags && tags.length > 0 && (
                 <>
                   <span className="px-4">{` • `}</span>

--- a/layouts/EventLayout.tsx
+++ b/layouts/EventLayout.tsx
@@ -6,6 +6,7 @@ import { PageSEO } from '@/components/SEO';
 import { siteMetadata } from '@/data/siteMetadata';
 import ScrollTop from '@/components/ScrollTop';
 import ExternalLink from '@/components/ExternalLink';
+import { DateDisplay } from '@/components/DateDisplay';
 
 const editUrl = (path) => `${siteMetadata.siteRepo}/blob/master/data/${path}`;
 
@@ -29,7 +30,7 @@ export default function PostLayout({ content, next, prev, children }: LayoutProp
         <h1 className="text-4xl font-medium leading-tight tracking-tight">{title}</h1>
 
         <div className="mt-6">
-          <time dateTime={content.date}>{content.displayDate}</time>
+          <DateDisplay dateString={content.displayDate} />
         </div>
       </header>
       <main className="container grid grid-cols-3 py-12 md:gap-16">

--- a/layouts/ListLayout.tsx
+++ b/layouts/ListLayout.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import { useRouter } from 'next/router';
-import { formatDate } from '@/lib/utils/formatDate';
 import { CoreContent } from '@/lib/utils/contentlayer';
 import type { Blog } from 'contentlayer/generated';
 import Link from 'next/link';
@@ -122,7 +121,7 @@ export default function ListLayout({
               path={post.path}
               tags={post.tags}
               summary={post.summary}
-              date={formatDate(post.date)}
+              date={post.date}
             />
           ))}
         </ul>

--- a/layouts/PostLayout.tsx
+++ b/layouts/PostLayout.tsx
@@ -4,11 +4,11 @@ import type { Blog, Authors } from 'contentlayer/generated';
 import Link from 'next/link';
 import { BlogSEO } from '@/components/SEO';
 import Image from '@/components/Image';
-import { formatDate } from '@/lib/utils/formatDate';
 import Tag from '@/components/Tag';
 import { siteMetadata } from '@/data/siteMetadata';
 import ScrollTop from '@/components/ScrollTop';
 import ExternalLink from '@/components/ExternalLink';
+import { DateDisplay } from '@/components/DateDisplay';
 
 const editUrl = (path) => `${siteMetadata.siteRepo}/blob/master/data/${path}`;
 
@@ -50,9 +50,7 @@ export default function PostLayout({ content, authorDetails, next, prev, childre
                   ))}
                 </ul>
                 <span className="px-1">on</span>
-                <time dateTime={date} suppressHydrationWarning>
-                  {formatDate(date)}
-                </time>
+                <DateDisplay dateString={date} />
               </div>
 
               <div className="mt-3 flex justify-center md:mt-0 md:justify-center">

--- a/layouts/PostSimple.tsx
+++ b/layouts/PostSimple.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from 'react';
-import { formatDate } from '@/lib/utils/formatDate';
+import { DateDisplay } from '@/components/DateDisplay';
 import { CoreContent } from '@/lib/utils/contentlayer';
 import type { Blog } from 'contentlayer/generated';
 import Link from 'next/link';
@@ -30,9 +30,7 @@ export default function PostLayout({ content, next, prev, children }: LayoutProp
                 <div>
                   <dt className="sr-only">Published on</dt>
                   <dd className="text-base font-medium leading-6 text-gray-500 dark:text-gray-400">
-                    <time dateTime={date} suppressHydrationWarning>
-                      {formatDate(date)}
-                    </time>
+                    <DateDisplay dateString={date} />
                   </dd>
                 </div>
               </dl>

--- a/lib/utils/date.ts
+++ b/lib/utils/date.ts
@@ -1,0 +1,5 @@
+export function toLocaleUTCDateString(date, locales, options) {
+  const timeDiff = date.getTimezoneOffset() * 60000;
+  const adjustedDate = new Date(date.valueOf() + timeDiff);
+  return adjustedDate.toLocaleDateString(locales, options);
+}

--- a/lib/utils/formatDate.ts
+++ b/lib/utils/formatDate.ts
@@ -1,5 +1,0 @@
-import { format } from 'date-fns';
-
-export const formatDate = (date: string) => {
-  return format(new Date(date), 'LLLL d, yyyy');
-};

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import Link from 'next/link';
 import { PageSEO } from '@/components/SEO';
 import { siteMetadata } from '@/data/siteMetadata';
-import { formatDate } from '@/lib/utils/formatDate';
 import { sortedBlogPost, allCoreContent, sortedEventPosts } from '@/lib/utils/contentlayer';
 import { InferGetStaticPropsType } from 'next';
 import { allBlogs, allEvents } from 'contentlayer/generated';
@@ -29,10 +28,10 @@ export default function Home({ posts, events }: InferGetStaticPropsType<typeof g
           Tailscale + Your machines = Access from anywhere
         </h1>
         <p className="mx-auto mb-6 max-w-3xl leading-6 sm:mb-8 sm:text-lg md:mb-10 md:text-xl">
-          Your laptop can be in Toronto, staging can be in Sunnyvale, production can be in
-          us-east-1, and all of that can be accessed from anywhere with an internet connection. Free
-          yourself from the slings and arrows of port forwarding and the fleeting hope that you
-          don&apos;t get hacked and just focus on what you do best.
+          Your laptop can be in Toronto, staging can be in Sunnyvale, production can be in{' '}
+          <code>us-east-1</code>, and all of that can be accessed from anywhere with an internet
+          connection. Free yourself from the slings and arrows of port forwarding and the fleeting
+          hope that you don&apos;t get hacked and just focus on what you do best.
         </p>
       </header>
       <main className="container max-w-4xl">
@@ -78,7 +77,7 @@ export default function Home({ posts, events }: InferGetStaticPropsType<typeof g
                 path={post.path}
                 tags={post.tags}
                 summary={post.summary}
-                date={formatDate(post.date)}
+                date={post.date}
               />
             ))}
           </ul>


### PR DESCRIPTION
Since Next.js server-side renders the page, the dates are parsed in UTC but then the page is hydrated on the client-side. This was resulting in incorrect dates. In the cases where we are displaying these dates, we don't want them to change, so we are now displaying the UTC date.

Resolves #45