### PR TITLE
css/tailwind: fix code snippets in dark mode

### DIFF
--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -743,7 +743,7 @@
 }
 
 .Markdown pre code {
-  @apply block overflow-x-auto px-4 py-3;
+  @apply block overflow-x-auto px-4 py-3 dark:bg-gray-800;
 }
 
 .Markdown h1 > code,
@@ -759,7 +759,7 @@
 .Markdown dd > code,
 .Markdown .note > code {
   @apply inline-block rounded-md border border-solid border-gray-200
-  bg-gray-100 py-0.5 px-1;
+  bg-gray-100 py-0.5 px-1 dark:bg-gray-800;
 }
 
 .Markdown figure:not(.customer-quote) {


### PR DESCRIPTION
Before there was no support for dark mode in code blocks. This gives code blocks in dark mode a nice contrasting shade of gray as a background.

Closes #60

![image](https://user-images.githubusercontent.com/529003/216669885-77ae6dd2-937f-476c-a912-3ce6e78df6c2.png)

Signed-off-by: Xe Iaso <xe@tailscale.com>