### PR TITLE
Excludes past events

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Events are located under `data/events` with the following front matter:
 - **date\*** (string, ANSI date)
 - **location\*** (string)
 - **summary\*** (string)
+- **endsDate** (string, ANSI date): last day of the event, defaults to **date**
 - **displayDate** (string)
 - **displayTime** (string)
 - **link** (string)

--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -63,6 +63,7 @@ export const Events = defineDocumentType(() => ({
     date: { type: 'date', required: true },
     location: { type: 'string', required: true },
     summary: { type: 'string', required: true },
+    endsDate: { type: 'date' },
     displayDate: { type: 'string' },
     displayTime: { type: 'string' },
     draft: { type: 'boolean' },

--- a/data/events/2023/fosdem.mdx
+++ b/data/events/2023/fosdem.mdx
@@ -2,6 +2,7 @@
 title: FOSDEM '23
 date: '2023-02-04'
 displayDate: 'February 4 – 5, 2023'
+endsDate: '2023-02-05'
 location: 'Brussels, Belgium'
 link: 'https://fosdem.org/2023/schedule/event/goheadscale/'
 summary: 'Headscale talk w/ Kristoffer Dalby & Juan Font Alonso -> Meetup @ BrewDog Brussels'

--- a/lib/utils/contentlayer.ts
+++ b/lib/utils/contentlayer.ts
@@ -18,6 +18,16 @@ export function sortedBlogPost(allBlogs: MDXDocumentDate[]) {
   return allBlogs.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
 }
 
+export function sortedFutureEventPosts(allEvents: MDXDocumentDate[]) {
+  return allEvents
+    .filter((e) => {
+      const date = new Date(e.endsDate || e.date);
+      date.setDate(date.getDate() + 1);
+      return date > new Date();
+    })
+    .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+}
+
 export function sortedEventPosts(allEvents: MDXDocumentDate[]) {
   return allEvents.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
 }

--- a/pages/events/index.tsx
+++ b/pages/events/index.tsx
@@ -1,6 +1,6 @@
 import { siteMetadata } from '@/data/siteMetadata';
 import { PageSEO } from '@/components/SEO';
-import { sortedEventPosts, allCoreContent } from '@/lib/utils/contentlayer';
+import { sortedFutureEventPosts, allCoreContent } from '@/lib/utils/contentlayer';
 import { InferGetStaticPropsType } from 'next';
 import { allEvents } from 'contentlayer/generated';
 import type { Events } from 'contentlayer/generated';
@@ -9,7 +9,7 @@ import { ListItem } from '@/components/ListItem';
 export const POSTS_PER_PAGE = 10;
 
 export const getStaticProps = async () => {
-  const events = sortedEventPosts(allEvents) as Events[];
+  const events = sortedFutureEventPosts(allEvents) as Events[];
   const initialDisplayPosts = events.slice(0, POSTS_PER_PAGE);
   const pagination = {
     currentPage: 1,

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Link from 'next/link';
 import { PageSEO } from '@/components/SEO';
 import { siteMetadata } from '@/data/siteMetadata';
-import { sortedBlogPost, allCoreContent, sortedEventPosts } from '@/lib/utils/contentlayer';
+import { sortedBlogPost, allCoreContent, sortedFutureEventPosts } from '@/lib/utils/contentlayer';
 import { InferGetStaticPropsType } from 'next';
 import { allBlogs, allEvents } from 'contentlayer/generated';
 import type { Blog, Events } from 'contentlayer/generated';
@@ -13,7 +13,7 @@ const MAX_POSTS_DISPLAY = 5;
 
 export const getStaticProps = async () => {
   const sortedPosts = sortedBlogPost(allBlogs) as Blog[];
-  const sortedEvents = sortedEventPosts(allEvents) as Events[];
+  const sortedEvents = sortedFutureEventPosts(allEvents) as Events[];
   const posts = allCoreContent(sortedPosts);
   const events = allCoreContent(sortedEvents);
 


### PR DESCRIPTION
Adds an optional `endsDate` to Events. Events are removed from the list one day after this date, however the event page will still exist through permalinks.

Closes #23

Home page:

![image](https://user-images.githubusercontent.com/40265/217104025-ebcf2303-6da2-4197-8dfe-04254cf3bde4.png)

Events page:

![image](https://user-images.githubusercontent.com/40265/217104062-a183abc0-704d-4588-898c-ce8b8e346e43.png)

Permalinks still work:

![image](https://user-images.githubusercontent.com/40265/217104161-ad9df35a-57b0-4212-912f-a6a4bd6d2b42.png)

