### PR TITLE
[events] Fixes event navigation

### DIFF
--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -77,6 +77,14 @@ export const Events = defineDocumentType(() => ({
       type: 'string',
       resolve: (doc) => (doc.displayDate ? doc.displayDate : doc.date),
     },
+    isFuture: {
+      type: 'boolean',
+      resolve: (doc) => {
+        const date = new Date(doc.endsDate || doc.date);
+        date.setDate(date.getDate() + 1);
+        return date > new Date();
+      },
+    },
   },
 }));
 

--- a/lib/utils/contentlayer.ts
+++ b/lib/utils/contentlayer.ts
@@ -1,5 +1,6 @@
 import GithubSlugger from 'github-slugger';
 import type { Document, MDX } from 'contentlayer/core';
+import type { Events } from 'contentlayer/generated';
 
 export type MDXDocument = Document & { body: MDX };
 export type MDXDocumentDate = MDXDocument & {
@@ -18,17 +19,13 @@ export function sortedBlogPost(allBlogs: MDXDocumentDate[]) {
   return allBlogs.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
 }
 
-export function sortedFutureEventPosts(allEvents: MDXDocumentDate[]) {
+export function sortedFutureEventPosts(allEvents: Events[]) {
   return allEvents
-    .filter((e) => {
-      const date = new Date(e.endsDate || e.date);
-      date.setDate(date.getDate() + 1);
-      return date > new Date();
-    })
+    .filter((e) => e.isFuture)
     .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
 }
 
-export function sortedEventPosts(allEvents: MDXDocumentDate[]) {
+export function sortedEventPosts(allEvents: Events[]) {
   return allEvents.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
 }
 

--- a/pages/events/[...slug].tsx
+++ b/pages/events/[...slug].tsx
@@ -4,7 +4,6 @@ import { MDXComponents } from '@/components/MDXComponents';
 import { sortedEventPosts, coreContent } from '@/lib/utils/contentlayer';
 import { InferGetStaticPropsType } from 'next';
 import { allEvents, allAuthors } from 'contentlayer/generated';
-import type { Events } from 'contentlayer/generated';
 
 const DEFAULT_LAYOUT = 'EventLayout';
 
@@ -17,13 +16,13 @@ export async function getStaticPaths() {
 
 export const getStaticProps = async ({ params }) => {
   const slug = (params.slug as string[]).join('/');
-  const sortedPosts = sortedEventPosts(allEvents) as Events[];
-  const postIndex = sortedPosts.findIndex((p) => p.slug === slug);
-  const prevContent = sortedPosts[postIndex + 1] || null;
-  const prev = prevContent ? coreContent(prevContent) : null;
-  const nextContent = sortedPosts[postIndex - 1] || null;
-  const next = nextContent ? coreContent(nextContent) : null;
-  const post = sortedPosts.find((p) => p.slug === slug);
+  const posts = sortedEventPosts(allEvents);
+  const futurePosts = posts.filter((e) => e.isFuture);
+
+  const postIndex = futurePosts.findIndex((p) => p.slug === slug);
+  const prev = futurePosts[postIndex - 1] || null;
+  const next = futurePosts[postIndex + 1] || null;
+  const post = posts.find((p) => p.slug === slug);
   const authorList = post.authors || ['default'];
   const authorDetails = authorList.map((author) => {
     const authorResults = allAuthors.find((p) => p.slug === author);


### PR DESCRIPTION
* Past events are no longer included.
* Previous/Next links resolve to the correct event. The ordering was previously in error, as events are ascending, and posts are descending.

Closes #76