### PR TITLE
Redirect for /up

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -64,6 +64,15 @@ module.exports = () => {
     eslint: {
       dirs: ['pages', 'components', 'lib', 'layouts', 'scripts'],
     },
+    async redirects() {
+      return [
+        {
+          source: '/up',
+          destination: 'https://ti.to/tailscaleup/2023',
+          permanent: false,
+        },
+      ];
+    },
     async headers() {
       return [
         {


### PR DESCRIPTION
Closes #87

```
% curl -I http://localhost:3000/up
HTTP/1.1 307 Temporary Redirect
Content-Security-Policy:   default-src 'self' js.tito.io;  script-src 'self' 'unsafe-eval' 'unsafe-inline' cdn.rudderlabs.com js.tito.io;  style-src 'self' 'unsafe-inline' js.tito.io;  img-src * blob: data:;  media-src 'none';  connect-src *;  font-src 'self';
Referrer-Policy: strict-origin-when-cross-origin
X-Frame-Options: DENY
X-Content-Type-Options: nosniff
X-DNS-Prefetch-Control: on
Strict-Transport-Security: max-age=31536000; includeSubDomains
Permissions-Policy: camera=(), microphone=(), geolocation=()
Location: https://ti.to/tailscaleup/2023
Date: Wed, 22 Feb 2023 23:19:49 GMT
Connection: keep-alive
Keep-Alive: timeout=5
```

Excerpt from [next.config.js/redirects docs](https://nextjs.org/docs/api-reference/next.config.js/redirects)
> Why does Next.js use 307 and 308? Traditionally a 302 was used for a temporary redirect, and a 301 for a permanent redirect, but many browsers changed the request method of the redirect to GET, regardless of the original method. For example, if the browser made a request to POST /v1/users which returned status code 302 with location /v2/users, the subsequent request might be GET /v2/users instead of the expected POST /v2/users. Next.js uses the 307 temporary redirect, and 308 permanent redirect status codes to explicitly preserve the request method used.