### PR TITLE
Applies prettier style to Github yaml

### DIFF
--- a/.github/ISSUE_TEMPLATE/article-ideas.yml
+++ b/.github/ISSUE_TEMPLATE/article-ideas.yml
@@ -1,13 +1,13 @@
-name: "Article Ideas"
-description: "Submit an idea for a blog post, integration, or how-to guide."
-title: "Article idea: "
-labels: ["article-idea", "triage"]
+name: 'Article Ideas'
+description: 'Submit an idea for a blog post, integration, or how-to guide.'
+title: 'Article idea: '
+labels: ['article-idea', 'triage']
 body:
   - type: dropdown
     id: section
     attributes:
       label: Section
-      description: "What section of the site would this appear?"
+      description: 'What section of the site would this appear?'
       options:
         - Blog
         - Use Cases
@@ -21,10 +21,10 @@ body:
     id: draft
     attributes:
       label: Draft
-      description: "Link to a draft of the article."
-      placeholder: "docs.google.com/..."
+      description: 'Link to a draft of the article.'
+      placeholder: 'docs.google.com/...'
   - type: textarea
     id: idea
     attributes:
       label: Idea
-      description: "Provide an overview of the idea for the article."
+      description: 'Provide an overview of the idea for the article.'


### PR DESCRIPTION
A test is [failing a PR](https://github.com/tailscale-dev/tailscale-dev/actions/runs/4284610929/jobs/7461804889) due to Prettier on the new issue template. I think it's a good idea to keep Prettier covering these configuration files as there is very little to provide validation on these types of changes.