### PR TITLE
Implement pronoun support

### DIFF
--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -1,4 +1,9 @@
-import { defineDocumentType, ComputedFields, makeSource } from 'contentlayer/source-files';
+import {
+  defineDocumentType,
+  defineNestedType,
+  ComputedFields,
+  makeSource,
+} from 'contentlayer/source-files';
 import readingTime from 'reading-time';
 
 // Remark packages
@@ -88,6 +93,14 @@ export const Events = defineDocumentType(() => ({
   },
 }));
 
+export const PronounSet = defineNestedType(() => ({
+  name: 'PronounSet',
+  fields: {
+    display: { type: 'string', required: true },
+    link: { type: 'string', required: true },
+  },
+}));
+
 export const Authors = defineDocumentType(() => ({
   name: 'Authors',
   filePathPattern: 'authors/**/*.mdx',
@@ -104,6 +117,7 @@ export const Authors = defineDocumentType(() => ({
     layout: { type: 'string' },
     website: { type: 'string' },
     fediverse: { type: 'string' },
+    pronouns: { type: 'nested', of: PronounSet },
   },
   computedFields: {
     ...computedFields,

--- a/data/authors/xe.mdx
+++ b/data/authors/xe.mdx
@@ -3,4 +3,7 @@ name: Xe Iaso
 avatar: /avatars/xe.png
 website: https://xeiaso.net
 fediverse: https://pony.social/@cadey
+pronouns:
+  display: 'they/them'
+  link: https://pronouns.within.lgbt/they/them/their/theirs/themselves
 ---

--- a/layouts/PostLayout.tsx
+++ b/layouts/PostLayout.tsx
@@ -44,8 +44,24 @@ export default function PostLayout({ content, authorDetails, next, prev, childre
                         rel="noreferer noopener noreferrer"
                         target="_blank"
                       >
-                        {author.name}
+                        {author.name}{' '}
                       </a>
+                      {author.pronouns != undefined ? (
+                        <>
+                          (
+                          <a
+                            className="whitespace-nowrap text-blue-300 transition-colors hover:text-blue-700"
+                            href={author.pronouns.link}
+                            rel="noreferer noopener noreferrer"
+                            target="_blank"
+                          >
+                            {author.pronouns.display}
+                          </a>
+                          )
+                        </>
+                      ) : (
+                        <></>
+                      )}
                     </li>
                   ))}
                 </ul>


### PR DESCRIPTION
To use, add this to your author page:

```yaml
pronouns:
  display: "they/them"
  link: https://pronouns.within.lgbt/they/them/their/theirs/themselves
```

You can use any page you want, but I suggest using a page from pronouns.within.lgbt[1] for uniformity's sake. This is left for any url in case there is a better page in an individual author's view.

Closes #40 

[1]: https://pronouns.within.lgbt/pronoun-list