### PR TITLE
add twitter card meta tags to SEO properties

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-yarn precommit
+./tool/yarn precommit

--- a/components/SEO.tsx
+++ b/components/SEO.tsx
@@ -18,7 +18,14 @@ interface CommonSEOProps {
   canonicalUrl?: string;
 }
 
-const CommonSEO = ({ title, description, ogType, ogImage, canonicalUrl }: CommonSEOProps) => {
+const CommonSEO = ({
+  title,
+  description,
+  ogType,
+  ogImage,
+  twImage,
+  canonicalUrl,
+}: CommonSEOProps) => {
   const router = useRouter();
   return (
     <Head>
@@ -35,6 +42,12 @@ const CommonSEO = ({ title, description, ogType, ogImage, canonicalUrl }: Common
       ) : (
         <meta property="og:image" content={ogImage} key={ogImage} />
       )}
+
+      <meta name="twitter:card" content="summary" />
+      <meta name="twitter:site" content="@tailscale" />
+      <meta name="twitter:description" content={description} />
+      <meta name="twitter:image" content={twImage} />
+
       <link
         rel="canonical"
         href={canonicalUrl ? canonicalUrl : `${siteMetadata.siteUrl}${router.asPath}`}


### PR DESCRIPTION
I believe this would close #107, but I have no idea what I'm doing. We may want to define the Twitter handle as a new property in the `siteMetadata` rather than hardcoding it here.