### PR TITLE
Use local yarn for precommit script even without direnv installed

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-yarn precommit
+tool/yarn precommit


### PR DESCRIPTION
Tiny fix PR without an issue, specifying the local yarn location for the precommit script in case the user doesn't have direnv installed.