### PR TITLE
[CI] Sets timeout for deploy

### DIFF
--- a/.github/workflows/fly.yml
+++ b/.github/workflows/fly.yml
@@ -9,6 +9,7 @@ jobs:
   deploy:
     name: Deploy app
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2


### PR DESCRIPTION
Have seen issues with deploying to Fly. Let's set an upper limit to minimize the CPU cycles and increase visibility when this happens.

Closes #113