### PR TITLE
css/prism: Fix syntax highlighting in light mode

### DIFF
--- a/css/prism.css
+++ b/css/prism.css
@@ -36,6 +36,29 @@
 }
 
 /* Token styles */
+
+code[class*='language-'],
+pre[class*='language-'] {
+  background: #27212e;
+  color: #ffffff;
+  font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace; /* this is the default */
+  /* The following properties are standard, please leave them as they are */
+  direction: ltr;
+  text-align: left;
+  white-space: pre;
+  word-spacing: normal;
+  word-break: normal;
+  line-height: 1.5;
+  -moz-tab-size: 2;
+  -o-tab-size: 2;
+  tab-size: 2;
+  /* The following properties are also standard */
+  -webkit-hyphens: none;
+  -moz-hyphens: none;
+  -ms-hyphens: none;
+  hyphens: none;
+}
+
 /**
  * MIT License
  * Copyright (c) 2018 Sarah Drasner


### PR DESCRIPTION
Closes #103

<img width="696" alt="Screenshot 2023-03-03 at 9 33 37 AM" src="https://user-images.githubusercontent.com/529003/222747233-ae2d743d-f4d8-4624-9573-8b3c771dfc06.png">
