### PR TITLE
css + blog/libtailscale: improve contrast for code blocks

### DIFF
--- a/css/prism.css
+++ b/css/prism.css
@@ -36,29 +36,6 @@
 }
 
 /* Token styles */
-
-code[class*='language-'],
-pre[class*='language-'] {
-  background: #27212e;
-  color: #ffffff;
-  font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace; /* this is the default */
-  /* The following properties are standard, please leave them as they are */
-  direction: ltr;
-  text-align: left;
-  white-space: pre;
-  word-spacing: normal;
-  word-break: normal;
-  line-height: 1.5;
-  -moz-tab-size: 2;
-  -o-tab-size: 2;
-  tab-size: 2;
-  /* The following properties are also standard */
-  -webkit-hyphens: none;
-  -moz-hyphens: none;
-  -ms-hyphens: none;
-  hyphens: none;
-}
-
 /**
  * MIT License
  * Copyright (c) 2018 Sarah Drasner

--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -746,13 +746,13 @@
 }
 
 .Markdown pre {
-  @apply mt-4 break-normal rounded-md border border-solid border-gray-200 bg-gray-100 leading-normal;
+  @apply mt-4 break-normal rounded-md border border-solid border-gray-800 bg-gray-800 leading-normal text-white;
   word-spacing: normal;
   tab-size: 2;
 }
 
 .Markdown pre code {
-  @apply block overflow-x-auto px-4 py-3 dark:bg-gray-800;
+  @apply block overflow-x-auto px-4 py-3;
 }
 
 .Markdown h1 > code,

--- a/data/blog/libtailscale.mdx
+++ b/data/blog/libtailscale.mdx
@@ -123,7 +123,7 @@ Combined with the second rule, it becomes effectively impossible to
 implement something that looks like a socket API directly as we do
 inside the Go `tsnet` package:
 
-```
+```c
 tailscale tailscale_new();
 int tailscale_dial(tailscale sd, const char* network, const char* addr, tailscale_conn* conn_out);
 ```
@@ -149,7 +149,7 @@ of objects stored in the kernel.
 
 We can do exactly the same thing for Go objects:
 
-```
+```go
 // servers tracks all the allocated *tsnet.Server objects.
 var servers struct {
         mu   sync.Mutex


### PR DESCRIPTION
Update syntax highlighting on libtailscale article.