### PR TITLE
Change twitter card type to summary_large_image

### DIFF
--- a/components/SEO.tsx
+++ b/components/SEO.tsx
@@ -43,7 +43,7 @@ const CommonSEO = ({
         <meta property="og:image" content={ogImage} key={ogImage} />
       )}
 
-      <meta name="twitter:card" content="summary" />
+      <meta name="twitter:card" content="summary_large_image" />
       <meta name="twitter:site" content="@tailscale" />
       <meta name="twitter:title" content={title} />
       <meta name="twitter:description" content={description} />


### PR DESCRIPTION
I think we have to explicitly specify the Twitter card type as `summary_large_image` for proper rendering on Twitter clients. (Our existing card type, `summary`, may render correctly when tweets are embedded elsewhere, but that doesn't help for twitter.com or the mobile apps.)