### PR TITLE
Extend page background color to overflow scroll

### DIFF
--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -14,6 +14,14 @@
     -webkit-tap-highlight-color: transparent;
   }
 
+  html.dark {
+    /**
+     * We can't use the dark: modifier here because it only applies to
+     * children of the html element, not the html element itself.
+     */
+    @apply bg-gray-900 text-white;
+  }
+
   body {
     @apply flex h-full flex-col justify-start text-base;
   }

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -18,7 +18,7 @@ class MyDocument extends Document {
             }}
           />
         </Head>
-        <body className="min-h-screen bg-white text-black antialiased dark:bg-gray-900 dark:text-white">
+        <body className="min-h-screen">
           <Main />
           <NextScript />
         </body>


### PR DESCRIPTION
When applying a background color to a page, it's better to apply it to the html element rather than the body element, because Firefox and Chrome use the html background color for the overflow scroll color. It's a subtle detail, but it makes the page feel more put-together.

This commit also removes classes that were unnecessarily applied twice from the CSS file and via classes.

https://user-images.githubusercontent.com/303731/226650282-0a3e5e80-c058-4327-a422-6d8ff9d3ed18.mp4

