### PR TITLE
components/image: remove <br /> from the Image component

### DIFF
--- a/components/image.tsx
+++ b/components/image.tsx
@@ -17,7 +17,6 @@ export default function Image(props: ImageComponentProps) {
         wrapper={(children) => <Link href={props.href}>{children}</Link>}
       >
         <div className={`rounded-xl ${props.className ? props.className : 'max-w-full'}`}>
-          <br />
           <NextImage {...props} />
         </div>
       </Wrapper>


### PR DESCRIPTION
It's strange that this was here so I'm suspicious how it made it in.

This looks to fix the issue with author images on blogs.

Fixes: #166