### PR TITLE
css: make first <p> in conversations not cause a newline

### DIFF
--- a/components/conv-snippet.tsx
+++ b/components/conv-snippet.tsx
@@ -20,7 +20,7 @@ export const ConvSnippet = ({ authors, name, children }: ConvSnippetProps) => {
       <div className="flex h-16 w-16 shrink-0 items-center justify-center self-center overflow-hidden rounded-lg bg-gray-200 dark:bg-gray-700">
         <Image src={author.avatar} width={64} height={64} alt={`the avatar for ${author.name}`} />
       </div>
-      <div className="min-w-0 self-center">
+      <div className="conversation-chat min-w-0 self-center">
         &lt;<b>{author.handle}</b>&gt; {children}
       </div>
     </div>

--- a/components/xesite-conv.tsx
+++ b/components/xesite-conv.tsx
@@ -20,7 +20,7 @@ export default function XesiteConv({ name, mood, children }: XesiteConvProps) {
           />
           <br />
         </div>
-        <div className="min-w-0 self-center">
+        <div className="conversation-chat min-w-0 self-center">
           &lt;<b>{name}</b>&gt; {children}
         </div>
       </div>

--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -756,6 +756,10 @@
   font-size: 1rem;
 }
 
+.conversation-chat p:first-of-type {
+  display: inline;
+}
+
 .Markdown h1 > code,
 .Markdown h2 > code,
 .Markdown h3 > code,


### PR DESCRIPTION
This happens because of a complicated interaction between our markdown parser, the formatter we use, and JSX syntax. If you don't do this, it injects a newline after the person/character name which breaks the illusion that the conversation snippets are IRC chatlogs.

I love computers.