### PR TITLE
[a11y] Improve contrast of image caption in dark mode

### DIFF
--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -795,7 +795,7 @@
 }
 
 .Markdown figcaption {
-  @apply mx-auto mt-2 w-3/4 text-center text-sm text-gray-600;
+  @apply mx-auto mt-2 w-3/4 text-center text-sm text-gray-600 dark:text-gray-300;
 }
 
 .Markdown aside {


### PR DESCRIPTION
The caption was not accounting for dark made, so was maintaining the dark gray making it hard to read.