### PR TITLE
[pages] Fix padding for upcoming events heading

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -66,9 +66,7 @@ export default function Home({ posts, events }: InferGetStaticPropsType<typeof g
         </div>
         <div className="md:basis-1/3">
           <div>
-            <h2 className="pt-6 pb-4 text-3xl font-bold leading-8 tracking-tight">
-              Upcoming Events
-            </h2>
+            <h2 className="pb-4 text-3xl font-bold leading-8 tracking-tight">Upcoming Events</h2>
             <ul>
               {!events.length && 'No events found.'}
               {events.slice(0, MAX_EVENTS_DISPLAY).map((event) => (


### PR DESCRIPTION
The "Upcoming Events" heading had a top padding that made it not line up with the "Latest Posts" heading.

before:

<img width="1019" alt="image" src="https://user-images.githubusercontent.com/40265/231665000-ddbf691f-213c-44c8-a66c-215541a4bb75.png">


after: 

<img width="1016" alt="image" src="https://user-images.githubusercontent.com/40265/231664878-eecdc93c-ee05-4427-8ae8-d1802f706bf0.png">
