### PR TITLE
Hide posts written in the future

### DIFF
--- a/layouts/list-layout.tsx
+++ b/layouts/list-layout.tsx
@@ -4,6 +4,7 @@ import { CoreContent } from '@/lib/utils/contentlayer';
 import type { Blog } from 'contentlayer/generated';
 import Link from 'next/link';
 import { ListItem } from '@/components/list-item';
+import { convertDateTimezone } from '@/lib/utils/date';
 
 interface PaginationProps {
   totalPages: number;
@@ -68,7 +69,9 @@ export default function ListLayout({
     return searchContent.toLowerCase().includes(searchValue.toLowerCase());
   });
 
-  initialDisplayPosts = initialDisplayPosts.filter((post) => new Date(post.date) <= new Date());
+  const now = convertDateTimezone(new Date(), 'America/New_York');
+
+  initialDisplayPosts = initialDisplayPosts.filter((post) => new Date(post.date) <= now);
 
   // If initialDisplayPosts exist, display it if no searchValue is specified
   const displayPosts =

--- a/layouts/list-layout.tsx
+++ b/layouts/list-layout.tsx
@@ -68,6 +68,8 @@ export default function ListLayout({
     return searchContent.toLowerCase().includes(searchValue.toLowerCase());
   });
 
+  initialDisplayPosts = initialDisplayPosts.filter((post) => new Date(post.date) <= new Date());
+
   // If initialDisplayPosts exist, display it if no searchValue is specified
   const displayPosts =
     initialDisplayPosts.length > 0 && !searchValue ? initialDisplayPosts : filteredBlogPosts;

--- a/lib/utils/date.ts
+++ b/lib/utils/date.ts
@@ -3,3 +3,7 @@ export function toLocaleUTCDateString(date, locales, options) {
   const adjustedDate = new Date(date.valueOf() + timeDiff);
   return adjustedDate.toLocaleDateString(locales, options);
 }
+
+export function convertDateTimezone(input: Date, zone: string): Date {
+  return new Date(Date.parse(input.toLocaleString('en-US', { timeZone: zone })));
+}

--- a/lib/utils/generate-rss.ts
+++ b/lib/utils/generate-rss.ts
@@ -1,4 +1,4 @@
-import { writeFileSync, mkdirSync } from 'fs';
+import { mkdirSync, writeFileSync } from 'fs';
 import path from 'path';
 import GithubSlugger from 'github-slugger';
 import { escape } from './html-escaper';
@@ -31,7 +31,8 @@ const generateRss = (
   allAuthors: MDXAuthor[],
   posts: MDXBlog[],
   page = 'feed.xml'
-) => `<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+) =>
+  `<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
     <channel>
       <title>${escape(config.title)}</title>
       <link>${config.siteUrl}/blog</link>
@@ -40,6 +41,7 @@ const generateRss = (
       <lastBuildDate>${new Date(posts[0].date).toUTCString()}</lastBuildDate>
       <atom:link href="${config.siteUrl}/${page}" rel="self" type="application/rss+xml"/>
       ${posts
+        .filter((post) => new Date(post.date) <= new Date())
         .map((post) => {
           const authorList = post.authors || ['default'];
           const authorDetails = authorList.map((author) => {

--- a/lib/utils/generate-rss.ts
+++ b/lib/utils/generate-rss.ts
@@ -4,6 +4,7 @@ import GithubSlugger from 'github-slugger';
 import { escape } from './html-escaper';
 import type { MDXAuthor, MDXBlog } from './contentlayer';
 import { getAllTags } from './contentlayer';
+import { convertDateTimezone } from './date';
 
 interface CoreConfig {
   title: string;
@@ -31,8 +32,9 @@ const generateRss = (
   allAuthors: MDXAuthor[],
   posts: MDXBlog[],
   page = 'feed.xml'
-) =>
-  `<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+) => {
+  const now = convertDateTimezone(new Date(), 'America/New_York');
+  return `<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
     <channel>
       <title>${escape(config.title)}</title>
       <link>${config.siteUrl}/blog</link>
@@ -41,7 +43,7 @@ const generateRss = (
       <lastBuildDate>${new Date(posts[0].date).toUTCString()}</lastBuildDate>
       <atom:link href="${config.siteUrl}/${page}" rel="self" type="application/rss+xml"/>
       ${posts
-        .filter((post) => new Date(post.date) <= new Date())
+        .filter((post) => new Date(post.date) <= now)
         .map((post) => {
           const authorList = post.authors || ['default'];
           const authorDetails = authorList.map((author) => {
@@ -54,6 +56,7 @@ const generateRss = (
     </channel>
   </rss>
 `;
+};
 
 export async function generateRSS(
   config: CoreConfig,

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -41,17 +41,20 @@ export default function Home({ posts, events }: InferGetStaticPropsType<typeof g
             <h2 className="pt-6 pb-4 text-3xl font-bold leading-8 tracking-tight">Latest Posts</h2>
             <ul>
               {!posts.length && 'No posts found.'}
-              {posts.slice(0, MAX_POSTS_DISPLAY).map((post) => (
-                <ListItem
-                  key={post.slug}
-                  title={post.title}
-                  slug={post.slug}
-                  path={post.path}
-                  tags={post.tags}
-                  summary={post.summary}
-                  date={post.date}
-                />
-              ))}
+              {posts
+                .slice(0, MAX_POSTS_DISPLAY)
+                .filter((post) => new Date(post.date) <= new Date())
+                .map((post) => (
+                  <ListItem
+                    key={post.slug}
+                    title={post.title}
+                    slug={post.slug}
+                    path={post.path}
+                    tags={post.tags}
+                    summary={post.summary}
+                    date={post.date}
+                  />
+                ))}
             </ul>
           </div>
           <div className="flex justify-end text-base font-medium leading-6">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -2,11 +2,12 @@ import React from 'react';
 import Link from 'next/link';
 import { PageSEO } from '@/components/seo';
 import { siteMetadata } from '@/data/site-metadata';
-import { sortedBlogPost, allCoreContent, sortedFutureEventPosts } from '@/lib/utils/contentlayer';
+import { allCoreContent, sortedBlogPost, sortedFutureEventPosts } from '@/lib/utils/contentlayer';
 import { InferGetStaticPropsType } from 'next';
 import { allBlogs, allEvents } from 'contentlayer/generated';
 import type { Blog, Events } from 'contentlayer/generated';
 import { ListItem } from '@/components/list-item';
+import { convertDateTimezone } from '@/lib/utils/date';
 
 const MAX_EVENTS_DISPLAY = 3;
 const MAX_POSTS_DISPLAY = 5;
@@ -21,6 +22,7 @@ export const getStaticProps = async () => {
 };
 
 export default function Home({ posts, events }: InferGetStaticPropsType<typeof getStaticProps>) {
+  const now = convertDateTimezone(new Date(), 'America/New_York');
   return (
     <>
       <PageSEO title={siteMetadata.title} description={siteMetadata.description} />
@@ -43,7 +45,7 @@ export default function Home({ posts, events }: InferGetStaticPropsType<typeof g
               {!posts.length && 'No posts found.'}
               {posts
                 .slice(0, MAX_POSTS_DISPLAY)
-                .filter((post) => new Date(post.date) <= new Date())
+                .filter((post) => new Date(post.date) <= now)
                 .map((post) => (
                   <ListItem
                     key={post.slug}


### PR DESCRIPTION
This checks the publication dates of posts to ensure that any posts scheduled for the future don't show up in lists, RSS feeds, or the homepage until that publication date becomes less than or equal to the present day in New York.

Fixes #47