### PR TITLE
search/index: Updates to index mapping

### DIFF
--- a/scripts/searchindex.ts
+++ b/scripts/searchindex.ts
@@ -1,110 +1,70 @@
 const { Client } = require('@elastic/elasticsearch');
 
+const defaultMapping = {
+  type: 'text',
+  fields: {
+    date: {
+      type: 'date',
+      format: 'strict_date_time||strict_date',
+      ignore_malformed: true,
+    },
+    delimiter: {
+      type: 'text',
+      index_options: 'freqs',
+      analyzer: 'iq_text_delimiter',
+    },
+    enum: {
+      type: 'keyword',
+      ignore_above: 2048,
+    },
+    float: {
+      type: 'double',
+      ignore_malformed: true,
+    },
+    joined: {
+      type: 'text',
+      index_options: 'freqs',
+      analyzer: 'i_text_bigram',
+      search_analyzer: 'q_text_bigram',
+    },
+    location: {
+      type: 'geo_point',
+      ignore_malformed: true,
+      ignore_z_value: false,
+    },
+    prefix: {
+      type: 'text',
+      index_options: 'docs',
+      analyzer: 'i_prefix',
+      search_analyzer: 'q_prefix',
+    },
+    stem: {
+      type: 'text',
+      analyzer: 'iq_text_stem',
+    },
+  },
+  index_options: 'freqs',
+  analyzer: 'iq_text_base',
+};
+
 const mappings = {
   dynamic: 'false',
   properties: {
-    body_content: {
-      type: 'text',
-      term_vector: 'with_positions_offsets',
-      analyzer: 'partial_match_analyzer',
-      fields: {
-        raw: {
-          type: 'keyword',
-        },
-      },
-    },
     id: {
       type: 'keyword',
     },
-    date: {
-      type: 'date',
-    },
-    tags: {
-      type: 'text',
-      term_vector: 'with_positions_offsets',
-      analyzer: 'partial_match_analyzer',
-      fields: {
-        raw: {
-          type: 'keyword',
-        },
-      },
-    },
-    title: {
-      type: 'text',
-      term_vector: 'with_positions_offsets',
-      analyzer: 'partial_match_analyzer',
-      fields: {
-        raw: {
-          type: 'keyword',
-        },
-      },
-    },
-    summary: {
-      type: 'text',
-      term_vector: 'with_positions_offsets',
-      analyzer: 'partial_match_analyzer',
-      fields: {
-        raw: {
-          type: 'keyword',
-        },
-      },
-    },
-    url: {
-      type: 'text',
-      fields: {
-        raw: {
-          type: 'keyword',
-        },
-      },
-    },
-    url_host: {
-      type: 'text',
-      fields: {
-        raw: {
-          type: 'keyword',
-        },
-      },
-    },
-    url_path: {
-      type: 'text',
-      fields: {
-        raw: {
-          type: 'keyword',
-        },
-      },
-    },
-    url_path_dir1: {
-      type: 'text',
-      fields: {
-        raw: {
-          type: 'keyword',
-        },
-      },
-    },
-    url_path_dir2: {
-      type: 'text',
-      fields: {
-        raw: {
-          type: 'keyword',
-        },
-      },
-    },
-    url_path_dir3: {
-      type: 'text',
-      fields: {
-        raw: {
-          type: 'keyword',
-        },
-      },
-    },
-    url_port: {
-      type: 'text',
-      fields: {
-        raw: {
-          type: 'keyword',
-        },
-      },
-    },
+    body_content: defaultMapping,
+    date: defaultMapping,
+    tags: defaultMapping,
+    title: defaultMapping,
+    summary: defaultMapping,
+    url: defaultMapping,
+    url_host: defaultMapping,
+    url_path: defaultMapping,
+    url_path_dir1: defaultMapping,
+    url_path_dir2: defaultMapping,
+    url_path_dir3: defaultMapping,
+    url_port: defaultMapping,
   },
 };
 
@@ -112,20 +72,107 @@ const settings = {
   index: {
     number_of_shards: 1,
     number_of_replicas: 1,
-    max_ngram_diff: 5,
   },
   analysis: {
-    analyzer: {
-      partial_match_analyzer: {
-        tokenizer: 'ngram_tokenizer',
-        filter: ['lowercase'],
+    filter: {
+      front_ngram: {
+        type: 'edge_ngram',
+        min_gram: '1',
+        max_gram: '12',
+      },
+      bigram_joiner: {
+        max_shingle_size: '2',
+        token_separator: '',
+        output_unigrams: 'false',
+        type: 'shingle',
+      },
+      bigram_max_size: {
+        type: 'length',
+        max: '16',
+        min: '0',
+      },
+      'en-stem-filter': {
+        name: 'light_english',
+        type: 'stemmer',
+      },
+      bigram_joiner_unigrams: {
+        max_shingle_size: '2',
+        token_separator: '',
+        output_unigrams: 'true',
+        type: 'shingle',
+      },
+      delimiter: {
+        split_on_numerics: 'true',
+        generate_word_parts: 'true',
+        preserve_original: 'false',
+        catenate_words: 'true',
+        generate_number_parts: 'true',
+        catenate_all: 'true',
+        split_on_case_change: 'true',
+        type: 'word_delimiter_graph',
+        catenate_numbers: 'true',
+        stem_english_possessive: 'true',
+      },
+      'en-stop-words-filter': {
+        type: 'stop',
+        stopwords: '_english_',
       },
     },
-    tokenizer: {
-      ngram_tokenizer: {
-        type: 'ngram',
-        min_gram: 2,
-        max_gram: 6,
+    analyzer: {
+      i_prefix: {
+        filter: ['cjk_width', 'lowercase', 'asciifolding', 'front_ngram'],
+        tokenizer: 'standard',
+      },
+      iq_text_delimiter: {
+        filter: [
+          'delimiter',
+          'cjk_width',
+          'lowercase',
+          'asciifolding',
+          'en-stop-words-filter',
+          'en-stem-filter',
+        ],
+        tokenizer: 'whitespace',
+      },
+      q_prefix: {
+        filter: ['cjk_width', 'lowercase', 'asciifolding'],
+        tokenizer: 'standard',
+      },
+      iq_text_base: {
+        filter: ['cjk_width', 'lowercase', 'asciifolding', 'en-stop-words-filter'],
+        tokenizer: 'standard',
+      },
+      iq_text_stem: {
+        filter: [
+          'cjk_width',
+          'lowercase',
+          'asciifolding',
+          'en-stop-words-filter',
+          'en-stem-filter',
+        ],
+        tokenizer: 'standard',
+      },
+      i_text_bigram: {
+        filter: [
+          'cjk_width',
+          'lowercase',
+          'asciifolding',
+          'en-stem-filter',
+          'bigram_joiner',
+          'bigram_max_size',
+        ],
+        tokenizer: 'standard',
+      },
+      q_text_bigram: {
+        filter: [
+          'cjk_width',
+          'lowercase',
+          'asciifolding',
+          'en-stem-filter',
+          'bigram_joiner_unigrams',
+          'bigram_max_size',
+        ],
+        tokenizer: 'standard',
       },
     },
   },


### PR DESCRIPTION
Takes from App Search and implements in the similar manner. It utilizes a standard mapping that is applied to all fields. This should make it easier as we start searching across indices.

Here is a sample search:

```
POST site-search-dev-blog/_search
{
  "from": 0,
  "size": 20,
  "highlight": {
    "fragment_size": 300,
    "number_of_fragments": 1,
    "type": "plain",
    "highlight_query": {
      "multi_match": {
        "query": "emac",
        "fields": [
          "body_content.prefix^1.0",
          "body_content.stem^1.0",
          "title.prefix^1.0",
          "title.stem^1.0",
          "summary.prefix^1.0",
          "summary.stem^1.0"
        ]
      }
    },
    "order": "score",
    "require_field_match": false,
    "fields": {
      "body_content.prefix": {
        "fragment_size": 150,
        "no_match_size": 150
      },
      "title.prefix": {
        "fragment_size": 150,
        "no_match_size": 150
      },
      "summary.prefix": {
        "fragment_size": 150,
        "no_match_size": 150
      }
    }
  },
  "query": {
    "bool": {
      "must": [
        {
          "multi_match": {
            "query": "emac",
            "fields": [
              "title^1.0",
              "title.delimiter^0.4",
              "title.joined^0.75",
              "title.prefix^0.1",
              "title.stem^0.95",
              "body_content^1.0",
              "body_content.delimiter^0.4",
              "body_content.joined^0.75",
              "body_content.prefix^0.1",
              "body_content.stem^0.95",
              "summary^1.0",
              "summary.delimiter^0.4",
              "summary.joined^0.75",
              "summary.prefix^0.1",
              "summary.stem^0.95"
            ],
            "type": "cross_fields",
            "minimum_should_match": "1<-1 3<49%"
          }
        }
      ]
    }
  },
  "fields": [
    "url",
    "title"
  ],
  "_source": false
}
```