### PR TITLE
scripts: add ElasticSearch janitor

### DIFF
--- a/.github/workflows/indexjanitor.yml
+++ b/.github/workflows/indexjanitor.yml
@@ -1,0 +1,24 @@
+name: 'Clean up old ElasticSearch indices'
+on:
+  schedule:
+    - cron: '42 0 * * *'
+jobs:
+  cleanup:
+    name: 'Do the cleanup'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+      - name: Run cleanup
+        run: yarn ci:indexjanitor
+        env:
+          DRY_RUN: 'false'
+          ELASTIC_URL: ${{ secrets.ELASTICSEARCH_URL }}
+          ELASTIC_USERNAME: ${{ secrets.ELASTICSEARCH_USERNAME }}
+          ELASTIC_PASSWORD: ${{ secrets.ELASTICSEARCH_PASSWORD }}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "precommit": "lint-staged",
     "lint": "next lint --fix",
     "prepare": "husky install",
+    "ci:indexjanitor": "node ./scripts/indexjanitor.js",
     "ci:searchindex": "ts-node ./scripts/searchindex.ts"
   },
   "dependencies": {

--- a/scripts/indexjanitor.js
+++ b/scripts/indexjanitor.js
@@ -1,0 +1,50 @@
+(async () => {
+  const { Client } = require('@elastic/elasticsearch');
+
+  const client = new Client({
+    node: {
+      url: new URL(process.env.ELASTIC_URL),
+    },
+    auth: {
+      username: process.env.ELASTIC_USERNAME,
+      password: process.env.ELASTIC_PASSWORD,
+    },
+    maxRetries: 5,
+    requestTimeout: 60000,
+  });
+
+  const aliasesToCareAbout = ['site-search-kb', 'site-search-dev-blog', 'site-search-xe-test'];
+
+  const dryRun = process.env.DRY_RUN ? process.env.DRY_RUN === 'false' : true;
+  console.log({ dryRun });
+
+  const indices = await client.indices.get({ index: 'site-search-*' });
+  const indicesToClose = [];
+  const safeIndices = [];
+
+  for (const alias of aliasesToCareAbout) {
+    const aliasMeta = await client.indices.getAlias({ name: alias });
+    const indexNames = Object.keys(aliasMeta);
+    safeIndices.push(...indexNames);
+  }
+
+  for (const index of Object.keys(indices)) {
+    if (!safeIndices.includes(index)) {
+      indicesToClose.push(index);
+    }
+  }
+
+  console.log(`Found ${indicesToClose.length} indices to close`);
+
+  if (dryRun) {
+    console.log('\nWould have closed:');
+    indicesToClose.forEach((index) => console.log(`- ${index}`));
+    console.log('\nDry run, not closing anything');
+    return;
+  }
+
+  for (const index of indicesToClose) {
+    console.log(`Closing ${index}`);
+    await client.indices.close({ index });
+  }
+})();


### PR DESCRIPTION
Our indexing process creates a lot of indices. This adds up and can make ElasticSearch fall over. This tool cleans up old indices by "closing" them. It closes every index that is not pointing to one of the aliases we care about.

This runs every night at 00:42 UTC. The significance of this number is an exercise for the reader.