### PR TITLE
components/layout-wrapper: fix header width issues

### DIFF
--- a/components/layout-wrapper.tsx
+++ b/components/layout-wrapper.tsx
@@ -41,30 +41,54 @@ const LayoutWrapper = ({ children }: Props) => {
             </Link>
             <ul className="relative hidden pt-8 md:flex">
               {leftHeaderNavLinks.map((link) => (
-                <li key={link.title}>
-                  <Link
-                    key={link.title}
-                    href={link.href}
-                    className="px-3 font-medium transition-colors duration-200 hover:text-gray-600"
-                  >
-                    <span>{link.title}</span>
-                    {link.href.startsWith('http') && (
-                      <span className="pl-1 text-gray-300">&#8599;</span>
-                    )}
-                  </Link>
-                </li>
+                <>
+                  <li key={link.title}>
+                    <Link
+                      key={link.title}
+                      href={link.href}
+                      className="px-1.5 lg:px-2 xl:px-3 font-medium transition-colors duration-200 hover:text-gray-600"
+                    >
+                      <span>{link.title}</span>
+                      {link.href.startsWith('http') && (
+                        <span className="pl-0.5 text-gray-300">&#8599;</span>
+                      )}
+                    </Link>
+                  </li>
+                </>
               ))}
+              {noSearch && (
+                <li className="px-1.5 lg:px-2 xl:px-3 font-medium transition-colors duration-200 hover:text-gray-600">
+                  <Link href="/search">Search</Link>
+                </li>
+              )}
             </ul>
-            {noSearch ? (
-              <></>
-            ) : (
-              <div className="px-3 pt-8 w-sm sm:invisible md:visible">
-                <SearchBar />
-              </div>
+            {noSearch == false && (
+              <>
+                <div className="px-1.25 lg:px-2 xl:px-3 pt-8 hidden md:block lg:hidden">
+                  <Link
+                    className="font-medium transition-colors duration-200 hover:text-gray-600"
+                    href="/search"
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      viewBox="0 0 20 20"
+                      fill="currentColor"
+                      className="h-5 w-5"
+                    >
+                      <path
+                        fillRule="evenodd"
+                        d="M9 3.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11zM2 9a7 7 0 1112.452 4.391l3.328 3.329a.75.75 0 11-1.06 1.06l-3.329-3.328A7 7 0 012 9z"
+                        clipRule="evenodd"
+                      />
+                    </svg>
+                  </Link>
+                </div>
+
+                <div className="px-3 pt-8 w-sm hidden lg:block">
+                  <SearchBar />
+                </div>
+              </>
             )}
-            <div className="px-3 pt-8 sm:visible md:invisible">
-              <Link href="/search">Search</Link>
-            </div>
           </div>
           <div className="ml-auto hidden pt-8 md:block">
             <ul className="flex items-center">
@@ -73,7 +97,7 @@ const LayoutWrapper = ({ children }: Props) => {
                   <Link
                     key={link.title}
                     href={link.href}
-                    className="px-3 font-medium  transition-colors duration-200 hover:text-gray-600"
+                    className="px-1.5 lg:px-2 xl:px-3 font-medium transition-colors duration-200 hover:text-gray-600"
                   >
                     <span>{link.title}</span>
                     {link.href.startsWith('http') && (
@@ -85,7 +109,7 @@ const LayoutWrapper = ({ children }: Props) => {
               <li>
                 <ThemeSwitch />
               </li>
-              <li className="ml-1 md:ml-4">
+              <li className="ml-0.5 md:ml-1.5 xl:ml-4">
                 <Link
                   href="https://login.tailscale.com/start"
                   data-track="Get Started Clicked"
@@ -93,7 +117,7 @@ const LayoutWrapper = ({ children }: Props) => {
                   target="_blank"
                   rel="noreferer noopener noreferrer"
                 >
-                  <span>Use Tailscale</span>
+                  <span className="hidden md:block">Login</span>
                 </Link>
               </li>
             </ul>

--- a/components/layout-wrapper.tsx
+++ b/components/layout-wrapper.tsx
@@ -56,39 +56,38 @@ const LayoutWrapper = ({ children }: Props) => {
                   </li>
                 </>
               ))}
-              {noSearch && (
+              {noSearch ? (
                 <li className="px-1.5 lg:px-2 xl:px-3 font-medium transition-colors duration-200 hover:text-gray-600">
                   <Link href="/search">Search</Link>
                 </li>
+              ) : (
+                <>
+                  <div className="px-1.25 lg:px-2 xl:px-3 pt-8 hidden md:block lg:hidden">
+                    <Link
+                      className="font-medium transition-colors duration-200 hover:text-gray-600"
+                      href="/search"
+                    >
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 20 20"
+                        fill="currentColor"
+                        className="h-5 w-5"
+                      >
+                        <path
+                          fillRule="evenodd"
+                          d="M9 3.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11zM2 9a7 7 0 1112.452 4.391l3.328 3.329a.75.75 0 11-1.06 1.06l-3.329-3.328A7 7 0 012 9z"
+                          clipRule="evenodd"
+                        />
+                      </svg>
+                    </Link>
+                  </div>
+
+                  <div className="px-3 pt-8 w-sm hidden lg:block">
+                    <SearchBar />
+                  </div>
+                </>
               )}
             </ul>
-            {noSearch == false && (
-              <>
-                <div className="px-1.25 lg:px-2 xl:px-3 pt-8 hidden md:block lg:hidden">
-                  <Link
-                    className="font-medium transition-colors duration-200 hover:text-gray-600"
-                    href="/search"
-                  >
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      viewBox="0 0 20 20"
-                      fill="currentColor"
-                      className="h-5 w-5"
-                    >
-                      <path
-                        fillRule="evenodd"
-                        d="M9 3.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11zM2 9a7 7 0 1112.452 4.391l3.328 3.329a.75.75 0 11-1.06 1.06l-3.329-3.328A7 7 0 012 9z"
-                        clipRule="evenodd"
-                      />
-                    </svg>
-                  </Link>
-                </div>
-
-                <div className="px-3 pt-8 w-sm hidden lg:block">
-                  <SearchBar />
-                </div>
-              </>
-            )}
           </div>
           <div className="ml-auto hidden pt-8 md:block">
             <ul className="flex items-center">

--- a/components/layout-wrapper.tsx
+++ b/components/layout-wrapper.tsx
@@ -14,6 +14,21 @@ interface Props {
   children: ReactNode;
 }
 
+const SearchIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 20 20"
+    fill="currentColor"
+    className="h-5 w-5"
+  >
+    <path
+      fillRule="evenodd"
+      d="M9 3.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11zM2 9a7 7 0 1112.452 4.391l3.328 3.329a.75.75 0 11-1.06 1.06l-3.329-3.328A7 7 0 012 9z"
+      clipRule="evenodd"
+    />
+  </svg>
+);
+
 // guide: https://nextjs.org/docs/basic-features/font-optimization#with-tailwind-css
 const inter = Inter({
   subsets: ['latin'],
@@ -39,7 +54,7 @@ const LayoutWrapper = ({ children }: Props) => {
                 <span className="pr-2 text-gray-700">~$</span>community
               </span>
             </Link>
-            <ul className="relative hidden pt-8 md:flex">
+            <ul className="relative hidden pt-8 md:flex items-center flex">
               {leftHeaderNavLinks.map((link) => (
                 <>
                   <li key={link.title}>
@@ -58,7 +73,12 @@ const LayoutWrapper = ({ children }: Props) => {
               ))}
               {noSearch ? (
                 <li className="px-1.5 lg:px-2 xl:px-3 font-medium transition-colors duration-200 hover:text-gray-600">
-                  <Link href="/search">Search</Link>
+                  <Link href="/search">
+                    <span className="hidden md:block lg:hidden">
+                      <SearchIcon />
+                    </span>
+                    <span className="hidden lg:block">Search</span>
+                  </Link>
                 </li>
               ) : (
                 <>
@@ -67,18 +87,7 @@ const LayoutWrapper = ({ children }: Props) => {
                       className="font-medium transition-colors duration-200 hover:text-gray-600"
                       href="/search"
                     >
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewBox="0 0 20 20"
-                        fill="currentColor"
-                        className="h-5 w-5"
-                      >
-                        <path
-                          fillRule="evenodd"
-                          d="M9 3.5a5.5 5.5 0 100 11 5.5 5.5 0 000-11zM2 9a7 7 0 1112.452 4.391l3.328 3.329a.75.75 0 11-1.06 1.06l-3.329-3.328A7 7 0 012 9z"
-                          clipRule="evenodd"
-                        />
-                      </svg>
+                      <SearchIcon />
                     </Link>
                   </div>
 

--- a/components/mobile-nav.tsx
+++ b/components/mobile-nav.tsx
@@ -18,7 +18,7 @@ const MobileNav = () => {
   };
 
   return (
-    <div className="sm:hidden">
+    <div className="md:hidden">
       <button
         className="ml-1 mr-1 h-8 w-8 rounded py-1"
         aria-label="Toggle Menu"
@@ -74,6 +74,15 @@ const MobileNav = () => {
               </Link>
             </div>
           ))}
+          <div className="px-12 py-4">
+            <Link
+              href="/search"
+              className="text-2xl font-bold tracking-widest text-gray-100"
+              onClick={onToggleNav}
+            >
+              Search
+            </Link>
+          </div>
           {rightHeaderNavLinks.map((link) => (
             <div key={link.title} className="px-12 py-4">
               <Link

--- a/components/search-bar.tsx
+++ b/components/search-bar.tsx
@@ -5,10 +5,10 @@ export default function SearchBar() {
 
   return (
     <>
-      <div className="relative flex flex-wrap items-stretch">
+      <div className="relative flex items-stretch">
         <input
           type="search"
-          className="relative m-0 block max-w-fit min-w-0 flex-auto rounded border border-solid border-neutral-300 bg-transparent bg-clip-padding px-3 py-[0.25rem] text-base font-normal leading-[1.6] text-neutral-700 outline-none transition duration-200 ease-in-out focus:z-[3] focus:border-primary focus:text-neutral-700 focus:shadow-[inset_0_0_0_1px_rgb(59,113,202)] focus:outline-none dark:border-neutral-600 dark:text-neutral-200 dark:placeholder:text-neutral-200 dark:focus:border-primary"
+          className="relative m-0 block max-w-10 min-w-0 flex-auto rounded border border-solid border-neutral-300 bg-transparent bg-clip-padding px-3 py-[0.25rem] text-base font-normal leading-[1.6] text-neutral-700 outline-none transition duration-200 ease-in-out focus:z-[3] focus:border-primary focus:text-neutral-700 focus:shadow-[inset_0_0_0_1px_rgb(59,113,202)] focus:outline-none dark:border-neutral-600 dark:text-neutral-200 dark:placeholder:text-neutral-200 dark:focus:border-primary"
           placeholder="Search"
           aria-label="Search"
           aria-describedby="button-addon2"

--- a/components/theme-switch.tsx
+++ b/components/theme-switch.tsx
@@ -11,7 +11,7 @@ const ThemeSwitch = () => {
   return (
     <button
       aria-label="Toggle Dark Mode"
-      className="ml-1 mr-1 h-8 w-8 rounded p-1 sm:ml-4"
+      className="ml-0.5 lg:ml-1 h-8 w-8 rounded p-1 sm:ml-4"
       onClick={() => setTheme(theme === 'dark' || resolvedTheme === 'dark' ? 'light' : 'dark')}
     >
       <svg

--- a/layouts/list-layout.tsx
+++ b/layouts/list-layout.tsx
@@ -76,7 +76,7 @@ export default function ListLayout({
       <header className="bg-gray-900 py-20 text-center text-gray-100">
         <h1 className="text-4xl font-medium leading-tight tracking-tight">{title}</h1>
         <div className="flex justify-center mt-6">
-          <div className="px-3 pt-8 max-w-md items-center sm:invisible md:visible">
+          <div className="px-3 pt-8 max-w-md items-center">
             <SearchBar />
           </div>
         </div>


### PR DESCRIPTION
While I was investigating #289 and #290, I found that there was an overall issue with header width. After adjusting all of the numbers to make the header look good on all our supported screen sizes, I think this should fix the root cause: invisible in Tailwind is not the same as hidden.

This should fix display on mobile phones as well as make the overall UX nicer on all browser widths.

Fixes #289
Fixes #290