### PR TITLE
Up: Removes link from header

### DIFF
--- a/data/header-nav-links.ts
+++ b/data/header-nav-links.ts
@@ -1,7 +1,6 @@
 export const leftHeaderNavLinks = [
   { href: '/events', title: 'Events' },
   { href: '/blog', title: 'Blog' },
-  { href: '/up', title: 'Up' },
 ];
 
 export const rightHeaderNavLinks = [


### PR DESCRIPTION
The event is over, so promotion in the header doesn't make much sense anymore. Additionally, with the addition of search things got pretty crowded.