### PR TITLE
disable renovate bot

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,7 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   extends: ['config:base'],
+  enabled: false,
   enabledManagers: ['npm'],
   baseBranches: ['main'],
   prConcurrentLimit: 0,


### PR DESCRIPTION
Since we're not keeping up with the dependency updates, it doesn't make sense to have them continue running CI jobs.

We can re-enable in the future as priorities change.